### PR TITLE
feat: add IA pressed state colors to Sky theme

### DIFF
--- a/Sources/Core/Resources/SkyColors.xcassets/States/ia-container-pressed.colorset/Contents.json
+++ b/Sources/Core/Resources/SkyColors.xcassets/States/ia-container-pressed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0xFA",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x28",
+          "red" : "0x02"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Core/Resources/SkyColors.xcassets/States/ia-pressed.colorset/Contents.json
+++ b/Sources/Core/Resources/SkyColors.xcassets/States/ia-pressed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0xB8",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0xA0",
+          "red" : "0x07"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Core/Scene/Other/Theme/Color/Sections/ViewModel/ColorSectionStatesViewModel.swift
+++ b/Sources/Core/Scene/Other/Theme/Color/Sections/ViewModel/ColorSectionStatesViewModel.swift
@@ -38,7 +38,9 @@ struct ColorSectionStatesViewModel: ColorSectionViewModelable {
                 .init(name: "infoPressed", colorToken: color.infoPressed),
                 .init(name: "infoContainerPressed", colorToken: color.infoContainerPressed),
                 .init(name: "neutralPressed", colorToken: color.neutralPressed),
-                .init(name: "neutralContainerPressed", colorToken: color.neutralContainerPressed)
+                .init(name: "neutralContainerPressed", colorToken: color.neutralContainerPressed),
+                .init(name: "iaPressed", colorToken: color.iaPressed),
+                .init(name: "iaContainerPressed", colorToken: color.iaContainerPressed)
             ]
         ]
     }

--- a/Sources/Core/Theme/Sky/SkyContent/SkyColors.swift
+++ b/Sources/Core/Theme/Sky/SkyContent/SkyColors.swift
@@ -99,7 +99,9 @@ struct SkyColors: Colors {
         infoPressed: ColorTokenDefault(named: "info-pressed", in: .module),
         infoContainerPressed: ColorTokenDefault(named: "info-container-pressed", in: .module),
         neutralPressed: ColorTokenDefault(named: "neutral-pressed", in: .module),
-        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module)
+        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module),
+        iaPressed: ColorTokenDefault(named: "ia-pressed", in: .module),
+        iaContainerPressed: ColorTokenDefault(named: "ia-container-pressed", in: .module)
     )
 
     let ia: any ColorsIA = ColorsIADefault(


### PR DESCRIPTION
- Add ia-pressed and ia-container-pressed color tokens to SkyColors
- Update ColorSectionStatesViewModel to display IA pressed states
- Add corresponding color assets for ia-pressed and ia-container-pressed states